### PR TITLE
Add configuration for haproxy 1.5+

### DIFF
--- a/configs/haproxy/haproxy.cfg
+++ b/configs/haproxy/haproxy.cfg
@@ -1,0 +1,57 @@
+global
+    daemon
+    pidfile /var/run/haproxy.pid
+    chroot  /var/lib/haproxy
+    user    haproxy
+    group   haproxy
+
+    log 127.0.0.1 local0
+    log 127.0.0.1 local1 notice
+
+    maxconn 1024
+    tune.ssl.default-dh-param 2048
+
+defaults
+    log    global
+    option dontlognull
+    option httplog
+
+    mode   http
+    option forwardfor
+    option http-server-close
+
+    timeout queue           1m
+    timeout connect         10s
+    timeout client          5m
+    timeout server          5m
+    timeout check           30s
+
+    stats  enable
+    stats  auth haproxy:PASSWORD
+    stats  uri /haproxyStats
+
+frontend http
+    bind 1.2.3.4:80
+
+    http-request set-header X-Forwarded-Proto http
+
+    default_backend application
+
+frontend https
+    bind 1.2.3.4:443 ssl crt /etc/haproxy/example.com.pem ciphers ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA
+    # For ssl client certificates, add the following to the previous line:
+    # ca-file /etc/ssl/ca.crt verify optional
+
+    http-request set-header X-Forwarded-Proto https
+
+    http-response set-header Strict-Transport-Security max-age=31536000;\ includeSubdomains
+    http-response set-header X-Frame-Options DENY
+
+    default_backend application
+
+backend application
+    redirect scheme https if !{ ssl_fc }
+    balance leastconn
+    option httpclose
+    option forwardfor
+    server node1 127.0.0.1:80 check 


### PR DESCRIPTION
Since release 1.5, haproxy can now terminate SSL. The configuration in this pull request is a variant of the one Pantheon (getpantheon.com) uses in production. haproxy implicitly restricts connections to SSLv3 and TLSv1.0+, with support for TLS 1.1 and 1.2.
